### PR TITLE
Adding the resource/resolver tree to support a single resource: orders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 export PIKACHU__ROUTES__GRAPHIQL__ENABLED=true
 export PIKACHU__DEBUG=true
 
+export PIKACHU__CLIENTS__CHARMANDER__BASE_URL=http://localhost:6999
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "@globality/nodule-graphql": "^0.29.0",
         "@globality/nodule-logging": "^1.5.0",
         "@globality/nodule-memcached": "^0.1.2",
-        "@globality/nodule-openapi": "^0.14.0",
+        "@globality/nodule-openapi": "^0.16.0",
         "apollo-server-core": "^1.4.0",
         "apollo-server-errors": "^2.0.2",
         "aws-sdk": "^2.392.0",

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import './resolvers';
 import './resources';
 import './routers';
 import './services';
+import './transforms';
 
 setDefaults('middleware.jwt', {
     realm: 'pikachu',

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { getContainer, setDefaults } from '@globality/nodule-config';
 import '@globality/nodule-express';
 import '@globality/nodule-logging';
+import { bindServices } from '@globality/nodule-graphql';
 
 // resolve graph dependencies
 import './clients';
@@ -26,9 +27,7 @@ export default function createApp() {
         gqlRouter,
     } = getContainer('routers');
 
-    // XXX this relies on internal libraries for instantiating service clients
-    // from swagger specs, which we will defer until later.
-    // bindServices();
+    bindServices();
     // enable routers
     express.use('/api', apiRouter);
     express.use('/gql', gqlRouter);

--- a/src/clients/index.js
+++ b/src/clients/index.js
@@ -1,0 +1,9 @@
+import { bind } from '@globality/nodule-config';
+import { createOpenAPIClient } from '@globality/nodule-openapi';
+
+import specs from './specs';
+
+
+Object.keys(specs).forEach((name) => {
+    bind(`clients.${name}`, () => createOpenAPIClient(name, specs[name]));
+});

--- a/src/clients/specs/charmander.v1.json
+++ b/src/clients/specs/charmander.v1.json
@@ -1,0 +1,1368 @@
+{
+  "basePath": "/api/v1", 
+  "consumes": [
+    "application/json"
+  ], 
+  "definitions": {
+    "Error": {
+      "properties": {
+        "code": {
+          "default": 500, 
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "context": {
+          "$ref": "#/definitions/ErrorContext"
+        }, 
+        "message": {
+          "default": "Unknown Error", 
+          "type": "string"
+        }, 
+        "retryable": {
+          "type": "boolean"
+        }
+      }, 
+      "required": [
+        "code", 
+        "message", 
+        "retryable"
+      ], 
+      "type": "object"
+    }, 
+    "ErrorContext": {
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/definitions/SubError"
+          }, 
+          "type": "array"
+        }
+      }, 
+      "required": [
+        "errors"
+      ], 
+      "type": "object"
+    }, 
+    "NewOrder": {
+      "properties": {
+        "customerId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "purpose": {
+          "enum": [
+            "CONTENT", 
+            "NORMAL", 
+            "TEST", 
+            "TUTORIAL", 
+            "REHEARSAL"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "customerId"
+      ], 
+      "type": "object"
+    }, 
+    "NewOrderEvent": {
+      "properties": {
+        "crustType": {
+          "enum": [
+            "REGULAR", 
+            "CHEESE_STUFFED"
+          ], 
+          "type": "string"
+        }, 
+        "customerId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "eventType": {
+          "enum": [
+            "OrderInitialized", 
+            "PizzaCreated", 
+            "PizzaToppingAdded", 
+            "PizzaCustomizationFinished", 
+            "OrderDeliveryDetailsAdded", 
+            "OrderSubmitted", 
+            "OrderFulfilled"
+          ], 
+          "type": "string"
+        }, 
+        "orderId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "pizzaSize": {
+          "enum": [
+            "PERSONAL", 
+            "REGULAR", 
+            "LARGE"
+          ], 
+          "type": "string"
+        }, 
+        "toppingType": {
+          "enum": [
+            "PEPPERONI", 
+            "MUSHROOM", 
+            "ONION", 
+            "SAUSAGE", 
+            "BACON", 
+            "OLIVE", 
+            "BELL_PEPPER", 
+            "PINEAPPLE", 
+            "SPINACH", 
+            "FOUR_CHEESE"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "eventType"
+      ], 
+      "type": "object"
+    }, 
+    "NewPizza": {
+      "properties": {
+        "crustType": {
+          "enum": [
+            "REGULAR", 
+            "CHEESE_STUFFED"
+          ], 
+          "type": "string"
+        }, 
+        "customerId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "orderId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "size": {
+          "enum": [
+            "PERSONAL", 
+            "REGULAR", 
+            "LARGE"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "crustType", 
+        "customerId", 
+        "orderId", 
+        "size"
+      ], 
+      "type": "object"
+    }, 
+    "NewTopping": {
+      "properties": {
+        "orderId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "pizzaId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "toppingType": {
+          "enum": [
+            "PEPPERONI", 
+            "MUSHROOM", 
+            "ONION", 
+            "SAUSAGE", 
+            "BACON", 
+            "OLIVE", 
+            "BELL_PEPPER", 
+            "PINEAPPLE", 
+            "SPINACH", 
+            "FOUR_CHEESE"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "orderId", 
+        "pizzaId", 
+        "toppingType"
+      ], 
+      "type": "object"
+    }, 
+    "Order": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "customerId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "id": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "purpose": {
+          "enum": [
+            "CONTENT", 
+            "NORMAL", 
+            "TEST", 
+            "TUTORIAL", 
+            "REHEARSAL"
+          ], 
+          "type": "string"
+        }, 
+        "resolution": {
+          "enum": [
+            "ACTIVE", 
+            "ARCHIVED", 
+            "ABANDONED", 
+            "CLOSED", 
+            "REDACTED", 
+            "STALE"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "customerId", 
+        "id"
+      ], 
+      "type": "object"
+    }, 
+    "OrderEvent": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "clock": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "createdAt": {
+          "format": "float", 
+          "type": "number"
+        }, 
+        "createdTimestamp": {
+          "format": "float", 
+          "type": "number"
+        }, 
+        "crustType": {
+          "enum": [
+            "REGULAR", 
+            "CHEESE_STUFFED"
+          ], 
+          "type": "string"
+        }, 
+        "customerId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "eventType": {
+          "enum": [
+            "OrderInitialized", 
+            "PizzaCreated", 
+            "PizzaToppingAdded", 
+            "PizzaCustomizationFinished", 
+            "OrderDeliveryDetailsAdded", 
+            "OrderSubmitted", 
+            "OrderFulfilled"
+          ], 
+          "type": "string"
+        }, 
+        "id": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "orderId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "parentId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "pizzaSize": {
+          "enum": [
+            "PERSONAL", 
+            "REGULAR", 
+            "LARGE"
+          ], 
+          "type": "string"
+        }, 
+        "toppingType": {
+          "enum": [
+            "PEPPERONI", 
+            "MUSHROOM", 
+            "ONION", 
+            "SAUSAGE", 
+            "BACON", 
+            "OLIVE", 
+            "BELL_PEPPER", 
+            "PINEAPPLE", 
+            "SPINACH", 
+            "FOUR_CHEESE"
+          ], 
+          "type": "string"
+        }, 
+        "version": {
+          "format": "int32", 
+          "type": "integer"
+        }
+      }, 
+      "required": [
+        "createdAt", 
+        "eventType", 
+        "id", 
+        "version"
+      ], 
+      "type": "object"
+    }, 
+    "OrderEventList": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "count": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "items": {
+          "items": {
+            "$ref": "#/definitions/OrderEvent"
+          }, 
+          "type": "array"
+        }, 
+        "limit": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "offset": {
+          "format": "int32", 
+          "type": "integer"
+        }
+      }, 
+      "required": [
+        "count", 
+        "items", 
+        "limit", 
+        "offset"
+      ], 
+      "type": "object"
+    }, 
+    "OrderList": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "count": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "items": {
+          "items": {
+            "$ref": "#/definitions/Order"
+          }, 
+          "type": "array"
+        }, 
+        "limit": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "offset": {
+          "format": "int32", 
+          "type": "integer"
+        }
+      }, 
+      "required": [
+        "count", 
+        "items", 
+        "limit", 
+        "offset"
+      ], 
+      "type": "object"
+    }, 
+    "Pizza": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "crustType": {
+          "enum": [
+            "REGULAR", 
+            "CHEESE_STUFFED"
+          ], 
+          "type": "string"
+        }, 
+        "customerId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "id": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "orderId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "size": {
+          "enum": [
+            "PERSONAL", 
+            "REGULAR", 
+            "LARGE"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "crustType", 
+        "customerId", 
+        "id", 
+        "orderId", 
+        "size"
+      ], 
+      "type": "object"
+    }, 
+    "PizzaList": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "count": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "items": {
+          "items": {
+            "$ref": "#/definitions/Pizza"
+          }, 
+          "type": "array"
+        }, 
+        "limit": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "offset": {
+          "format": "int32", 
+          "type": "integer"
+        }
+      }, 
+      "required": [
+        "count", 
+        "items", 
+        "limit", 
+        "offset"
+      ], 
+      "type": "object"
+    }, 
+    "SubError": {
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "message"
+      ], 
+      "type": "object"
+    }, 
+    "Topping": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "id": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "orderId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "pizzaId": {
+          "format": "uuid", 
+          "type": "string"
+        }, 
+        "toppingType": {
+          "enum": [
+            "PEPPERONI", 
+            "MUSHROOM", 
+            "ONION", 
+            "SAUSAGE", 
+            "BACON", 
+            "OLIVE", 
+            "BELL_PEPPER", 
+            "PINEAPPLE", 
+            "SPINACH", 
+            "FOUR_CHEESE"
+          ], 
+          "type": "string"
+        }
+      }, 
+      "required": [
+        "id", 
+        "orderId", 
+        "pizzaId", 
+        "toppingType"
+      ], 
+      "type": "object"
+    }, 
+    "ToppingList": {
+      "properties": {
+        "_links": {
+          "type": "object"
+        }, 
+        "count": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "items": {
+          "items": {
+            "$ref": "#/definitions/Topping"
+          }, 
+          "type": "array"
+        }, 
+        "limit": {
+          "format": "int32", 
+          "type": "integer"
+        }, 
+        "offset": {
+          "format": "int32", 
+          "type": "integer"
+        }
+      }, 
+      "required": [
+        "count", 
+        "items", 
+        "limit", 
+        "offset"
+      ], 
+      "type": "object"
+    }
+  }, 
+  "info": {
+    "title": "charmander", 
+    "version": "v1"
+  }, 
+  "paths": {
+    "/order": {
+      "get": {
+        "operationId": "search", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "customer_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "limit", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "offset", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "enum": [
+              "CONTENT", 
+              "NORMAL", 
+              "TEST", 
+              "TUTORIAL", 
+              "REHEARSAL"
+            ], 
+            "in": "query", 
+            "name": "purpose", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "ACTIVE", 
+              "ARCHIVED", 
+              "ABANDONED", 
+              "CLOSED", 
+              "REDACTED", 
+              "STALE"
+            ], 
+            "in": "query", 
+            "name": "resolution", 
+            "required": false, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Search the collection of all orders", 
+            "schema": {
+              "$ref": "#/definitions/OrderList"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "order"
+        ]
+      }, 
+      "post": {
+        "operationId": "create", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "in": "body", 
+            "name": "body", 
+            "schema": {
+              "$ref": "#/definitions/NewOrder"
+            }
+          }
+        ], 
+        "responses": {
+          "201": {
+            "description": "Create a new order", 
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "order"
+        ]
+      }
+    }, 
+    "/order/{order_id}": {
+      "get": {
+        "operationId": "retrieve", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "order_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Retrieve a order by id", 
+            "schema": {
+              "$ref": "#/definitions/Order"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "order"
+        ]
+      }
+    }, 
+    "/order_event": {
+      "get": {
+        "operationId": "search", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "clock", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "enum": [
+              "REGULAR", 
+              "CHEESE_STUFFED"
+            ], 
+            "in": "query", 
+            "name": "crust_type", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "customer_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "OrderInitialized", 
+              "PizzaCreated", 
+              "PizzaToppingAdded", 
+              "PizzaCustomizationFinished", 
+              "OrderDeliveryDetailsAdded", 
+              "OrderSubmitted", 
+              "OrderFulfilled"
+            ], 
+            "in": "query", 
+            "name": "event_type", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "limit", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "max_clock", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "min_clock", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "offset", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "order_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "parent_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "PERSONAL", 
+              "REGULAR", 
+              "LARGE"
+            ], 
+            "in": "query", 
+            "name": "pizza_size", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "CONTENT", 
+              "NORMAL", 
+              "TEST", 
+              "TUTORIAL", 
+              "REHEARSAL"
+            ], 
+            "in": "query", 
+            "name": "purpose", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "ACTIVE", 
+              "ARCHIVED", 
+              "ABANDONED", 
+              "CLOSED", 
+              "REDACTED", 
+              "STALE"
+            ], 
+            "in": "query", 
+            "name": "resolution", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "in": "query", 
+            "name": "sort_by_clock", 
+            "required": false, 
+            "type": "boolean"
+          }, 
+          {
+            "in": "query", 
+            "name": "sort_clock_in_ascending_order", 
+            "required": false, 
+            "type": "boolean"
+          }, 
+          {
+            "enum": [
+              "PEPPERONI", 
+              "MUSHROOM", 
+              "ONION", 
+              "SAUSAGE", 
+              "BACON", 
+              "OLIVE", 
+              "BELL_PEPPER", 
+              "PINEAPPLE", 
+              "SPINACH", 
+              "FOUR_CHEESE"
+            ], 
+            "in": "query", 
+            "name": "topping_type", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "version", 
+            "required": false, 
+            "type": "integer"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Search the collection of all order_events", 
+            "schema": {
+              "$ref": "#/definitions/OrderEventList"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "order_event"
+        ]
+      }, 
+      "post": {
+        "operationId": "create", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "in": "body", 
+            "name": "body", 
+            "schema": {
+              "$ref": "#/definitions/NewOrderEvent"
+            }
+          }
+        ], 
+        "responses": {
+          "201": {
+            "description": "Create a new order_event", 
+            "schema": {
+              "$ref": "#/definitions/OrderEvent"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "order_event"
+        ]
+      }
+    }, 
+    "/order_event/{order_event_id}": {
+      "get": {
+        "operationId": "retrieve", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "order_event_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Retrieve a order_event by id", 
+            "schema": {
+              "$ref": "#/definitions/OrderEvent"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "order_event"
+        ]
+      }
+    }, 
+    "/pizza": {
+      "get": {
+        "operationId": "search", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "REGULAR", 
+              "CHEESE_STUFFED"
+            ], 
+            "in": "query", 
+            "name": "crust_type", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "customer_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "limit", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "offset", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "order_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "PERSONAL", 
+              "REGULAR", 
+              "LARGE"
+            ], 
+            "in": "query", 
+            "name": "size", 
+            "required": false, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Search the collection of all pizzas", 
+            "schema": {
+              "$ref": "#/definitions/PizzaList"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "pizza"
+        ]
+      }, 
+      "post": {
+        "operationId": "create", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "in": "body", 
+            "name": "body", 
+            "schema": {
+              "$ref": "#/definitions/NewPizza"
+            }
+          }
+        ], 
+        "responses": {
+          "201": {
+            "description": "Create a new pizza", 
+            "schema": {
+              "$ref": "#/definitions/Pizza"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "pizza"
+        ]
+      }
+    }, 
+    "/pizza/{pizza_id}": {
+      "delete": {
+        "operationId": "delete", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "pizza_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "204": {
+            "description": "Delete a pizza by id"
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "pizza"
+        ]
+      }, 
+      "get": {
+        "operationId": "retrieve", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "pizza_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Retrieve a pizza by id", 
+            "schema": {
+              "$ref": "#/definitions/Pizza"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "pizza"
+        ]
+      }, 
+      "put": {
+        "operationId": "replace", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "in": "body", 
+            "name": "body", 
+            "schema": {
+              "$ref": "#/definitions/NewPizza"
+            }
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "pizza_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Create or update a pizza by id", 
+            "schema": {
+              "$ref": "#/definitions/Pizza"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "pizza"
+        ]
+      }
+    }, 
+    "/topping": {
+      "get": {
+        "operationId": "search", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "limit", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "int32", 
+            "in": "query", 
+            "name": "offset", 
+            "required": false, 
+            "type": "integer"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "order_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "query", 
+            "name": "pizza_id", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "enum": [
+              "PEPPERONI", 
+              "MUSHROOM", 
+              "ONION", 
+              "SAUSAGE", 
+              "BACON", 
+              "OLIVE", 
+              "BELL_PEPPER", 
+              "PINEAPPLE", 
+              "SPINACH", 
+              "FOUR_CHEESE"
+            ], 
+            "in": "query", 
+            "name": "topping_type", 
+            "required": false, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Search the collection of all toppings", 
+            "schema": {
+              "$ref": "#/definitions/ToppingList"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "topping"
+        ]
+      }, 
+      "post": {
+        "operationId": "create", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "in": "body", 
+            "name": "body", 
+            "schema": {
+              "$ref": "#/definitions/NewTopping"
+            }
+          }
+        ], 
+        "responses": {
+          "201": {
+            "description": "Create a new topping", 
+            "schema": {
+              "$ref": "#/definitions/Topping"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "topping"
+        ]
+      }
+    }, 
+    "/topping/{topping_id}": {
+      "delete": {
+        "operationId": "delete", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "topping_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "204": {
+            "description": "Delete a topping by id"
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "topping"
+        ]
+      }, 
+      "get": {
+        "operationId": "retrieve", 
+        "parameters": [
+          {
+            "in": "header", 
+            "name": "X-Response-Skip-Null", 
+            "required": false, 
+            "type": "string"
+          }, 
+          {
+            "format": "uuid", 
+            "in": "path", 
+            "name": "topping_id", 
+            "required": true, 
+            "type": "string"
+          }
+        ], 
+        "responses": {
+          "200": {
+            "description": "Retrieve a topping by id", 
+            "schema": {
+              "$ref": "#/definitions/Topping"
+            }
+          }, 
+          "default": {
+            "description": "An error occurred", 
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }, 
+        "tags": [
+          "topping"
+        ]
+      }
+    }
+  }, 
+  "produces": [
+    "application/json"
+  ], 
+  "swagger": "2.0"
+}

--- a/src/clients/specs/index.js
+++ b/src/clients/specs/index.js
@@ -1,0 +1,20 @@
+import { readdirSync, readFileSync } from 'fs';
+
+const specsDict = {};
+const specs = {};
+
+
+readdirSync(__dirname).forEach((file) => {
+    if (file.endsWith('.json')) {
+        const [service, version] = file.split('.');
+        const spec = JSON.parse(readFileSync(`${__dirname}/${file}`));
+        if (!specsDict[service]) {
+            specsDict[service] = {};
+        }
+        specsDict[service][version] = spec;
+    }
+});
+
+specs.charmander = specsDict.charmander.v1;
+
+export default specs;

--- a/src/resolvers/index.js
+++ b/src/resolvers/index.js
@@ -1,0 +1,1 @@
+import './order';

--- a/src/resolvers/order/create.js
+++ b/src/resolvers/order/create.js
@@ -1,0 +1,20 @@
+import { createResolver } from '@globality/nodule-graphql';
+import { bind, getContainer } from '@globality/nodule-config';
+
+async function aggregate({ input: { customerId } }, req) {
+    const { charmander } = getContainer('services');
+
+    return charmander.order.create(req, {
+        body: {
+            customerId,
+        },
+    });
+}
+
+
+const resolver = createResolver({
+    aggregate,
+    mask: (obj, args, req) => [args, req],
+});
+
+bind('graphql.resolvers.order.create', () => resolver);

--- a/src/resolvers/order/index.js
+++ b/src/resolvers/order/index.js
@@ -1,0 +1,1 @@
+import './retrieve';

--- a/src/resolvers/order/index.js
+++ b/src/resolvers/order/index.js
@@ -1,1 +1,3 @@
+import './create';
 import './retrieve';
+import './search';

--- a/src/resolvers/order/retrieve.js
+++ b/src/resolvers/order/retrieve.js
@@ -1,0 +1,22 @@
+import { createResolver } from '@globality/nodule-graphql';
+import { bind, getContainer } from '@globality/nodule-config';
+
+
+async function aggregate( { id: orderId },  req) {
+    const { charmander } = getContainer('services');
+
+    if (!orderId) {
+        return {};
+    }
+
+    return charmander.order.retrieve(req, {
+        orderId,
+    });
+}
+
+const resolver = createResolver({
+    aggregate,
+    mask: (obj, args, context, req) => [args, req],
+});
+
+bind('graphql.resolvers.order.retrieve', () => resolver);

--- a/src/resolvers/order/search.js
+++ b/src/resolvers/order/search.js
@@ -2,15 +2,11 @@ import { createResolver } from '@globality/nodule-graphql';
 import { bind, getContainer } from '@globality/nodule-config';
 
 
-async function aggregate({ id: orderId }, req) {
+async function aggregate({ customerId }, req) {
     const { charmander } = getContainer('services');
 
-    if (!orderId) {
-        return {};
-    }
-
-    return charmander.order.retrieve(req, {
-        orderId,
+    return charmander.order.search(req, {
+        customerId,
     });
 }
 
@@ -19,4 +15,4 @@ const resolver = createResolver({
     mask: (obj, args, context, req) => [args, req],
 });
 
-bind('graphql.resolvers.order.retrieve', () => resolver);
+bind('graphql.resolvers.order.search', () => resolver);

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -2,9 +2,8 @@ import { GraphQLObjectType, GraphQLSchema } from 'graphql';
 
 import { bind } from '@globality/nodule-config';
 
-import { Order } from './order/types';
-
-console.log("order ", Order);
+import OrderMutations from './order/mutations';
+import Order from './order/queries';
 
 
 const QueryType = new GraphQLObjectType({
@@ -19,13 +18,13 @@ const MutationType = new GraphQLObjectType({
     name: 'Mutations',
     description: 'These are the things we can change',
     fields: {
+        ...OrderMutations,
     },
 });
 
 bind('graphql.QueryType', () => QueryType);
 bind('graphql.MutationType', () => MutationType);
-bind('graphql.schema', ({ QueryType, MutationType }) => new GraphQLSchema({
+bind('graphql.schema', () => new GraphQLSchema({
     query: QueryType,
-//    mutation: MutationType, mutation type can't be empty, readd when we have
-//    mutations!
+    mutation: MutationType,
 }));

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -1,0 +1,31 @@
+import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+
+import { bind } from '@globality/nodule-config';
+
+import { Order } from './order/types';
+
+console.log("order ", Order);
+
+
+const QueryType = new GraphQLObjectType({
+    name: 'QueryType',
+    description: 'Top-level entry points',
+    fields: {
+        ...Order,
+    },
+});
+
+const MutationType = new GraphQLObjectType({
+    name: 'Mutations',
+    description: 'These are the things we can change',
+    fields: {
+    },
+});
+
+bind('graphql.QueryType', () => QueryType);
+bind('graphql.MutationType', () => MutationType);
+bind('graphql.schema', ({ QueryType, MutationType }) => new GraphQLSchema({
+    query: QueryType,
+//    mutation: MutationType, mutation type can't be empty, readd when we have
+//    mutations!
+}));

--- a/src/resources/order/__tests__/OrderCreate.test.js
+++ b/src/resources/order/__tests__/OrderCreate.test.js
@@ -1,0 +1,47 @@
+
+import request from 'supertest';
+import { Nodule } from '@globality/nodule-config';
+import { mockResponse } from '@globality/nodule-openapi';
+import createApp from '../../../app';
+
+let app;
+
+
+beforeEach(async () => {
+    await Nodule.testing().fromObject(
+        mockResponse('charmander', 'order.create', {
+            id: '00000000-0000-0000-0000-000000000000',
+            customerId: '00000000-0000-0000-0000-111111111111',
+        }),
+    ).load();
+
+    app = createApp();
+});
+
+it('should create an order', async () => {
+    const query = `
+        mutation createOrder($input: OrderCreateInputType) {
+          orderCreate(input: $input) {
+            id
+            customerId
+          }
+        }
+    `;
+
+    const variables = {
+        input: {
+            customerId: '00000000-0000-0000-0000-111111111111',
+        },
+    };
+
+
+    const result = await request(app).post(
+        '/gql/graphql',
+    ).send({
+        query,
+        variables,
+    });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body).toMatchSnapshot();
+});

--- a/src/resources/order/__tests__/OrderRetrieve.test.js
+++ b/src/resources/order/__tests__/OrderRetrieve.test.js
@@ -1,0 +1,46 @@
+import request from 'supertest';
+import { Nodule } from '@globality/nodule-config';
+import { mockResponse } from '@globality/nodule-openapi';
+import createApp from '../../../app';
+
+let app;
+
+
+beforeEach(async () => {
+    await Nodule.testing().fromObject(
+        mockResponse('charmander', 'order.retrieve', {
+            id: '00000000-0000-0000-0000-000000000000',
+            customerId: '00000000-0000-0000-0000-111111111111',
+        }),
+    ).load();
+
+    app = createApp();
+});
+
+it('should retrieve a single order', async () => {
+    const query = `
+        query retrieveOrder($orderId: ID) {
+          order(id: $orderId) {
+            items {
+                id
+                customerId
+            }
+          }
+        }
+    `;
+
+    const variables = {
+        orderId: '00000000-0000-0000-0000-111111111111',
+    };
+
+
+    const result = await request(app).post(
+        '/gql/graphql',
+    ).send({
+        query,
+        variables,
+    });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body).toMatchSnapshot();
+});

--- a/src/resources/order/__tests__/OrderSearch.test.js
+++ b/src/resources/order/__tests__/OrderSearch.test.js
@@ -1,0 +1,78 @@
+import request from 'supertest';
+import { Nodule } from '@globality/nodule-config';
+import { mockResponse } from '@globality/nodule-openapi';
+import createApp from '../../../app';
+
+let app;
+
+
+beforeEach(async () => {
+    await Nodule.testing().fromObject(
+        mockResponse('charmander', 'order.search', {
+            count: 2,
+            items: [
+                {
+                    id: '00000000-0000-0000-0000-000000000000',
+                    customerId: '00000000-0000-0000-0000-111111111111',
+                },
+                {
+                    id: '00000000-0000-0000-0000-000000000000',
+                    customerId: '00000000-0000-0000-0000-111111111112',
+                },
+            ],
+        }),
+    ).load();
+
+    app = createApp();
+});
+
+
+it('should retrieve a list of orders', async () => {
+    const query = `
+        query {
+          order {
+            items {
+                id
+                customerId
+            }
+          }
+        }
+    `;
+
+    const result = await request(app).post(
+        '/gql/graphql',
+    ).send({
+        query,
+    });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body).toMatchSnapshot();
+});
+
+
+it('should retrieve all orders for customer id', async () => {
+    const query = `
+        query($customerId: ID) {
+          order(customerId: $customerId) {
+            items {
+                id
+                customerId
+            }
+          }
+        }
+    `;
+
+    const variables = {
+        customerId: '00000000-0000-0000-0000-111111111111',
+    };
+
+    const result = await request(app).post(
+        '/gql/graphql',
+    ).send({
+        query,
+        variables,
+    });
+
+    expect(result.body.errors).toBeUndefined();
+    expect(result.body).toMatchSnapshot();
+});

--- a/src/resources/order/__tests__/__snapshots__/OrderCreate.test.js.snap
+++ b/src/resources/order/__tests__/__snapshots__/OrderCreate.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should create an order 1`] = `
+Object {
+  "data": Object {
+    "orderCreate": Object {
+      "customerId": "00000000-0000-0000-0000-111111111111",
+      "id": "00000000-0000-0000-0000-000000000000",
+    },
+  },
+}
+`;

--- a/src/resources/order/__tests__/__snapshots__/OrderRetrieve.test.js.snap
+++ b/src/resources/order/__tests__/__snapshots__/OrderRetrieve.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should retrieve a single order 1`] = `
+Object {
+  "data": Object {
+    "order": Object {
+      "items": Array [
+        Object {
+          "customerId": "00000000-0000-0000-0000-111111111111",
+          "id": "00000000-0000-0000-0000-000000000000",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/src/resources/order/__tests__/__snapshots__/OrderSearch.test.js.snap
+++ b/src/resources/order/__tests__/__snapshots__/OrderSearch.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should retrieve a list of orders 1`] = `
+Object {
+  "data": Object {
+    "order": Object {
+      "items": Array [
+        Object {
+          "customerId": "00000000-0000-0000-0000-111111111111",
+          "id": "00000000-0000-0000-0000-000000000000",
+        },
+        Object {
+          "customerId": "00000000-0000-0000-0000-111111111112",
+          "id": "00000000-0000-0000-0000-000000000000",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`should retrieve all orders for customer id 1`] = `
+Object {
+  "data": Object {
+    "order": Object {
+      "items": Array [
+        Object {
+          "customerId": "00000000-0000-0000-0000-111111111111",
+          "id": "00000000-0000-0000-0000-000000000000",
+        },
+        Object {
+          "customerId": "00000000-0000-0000-0000-111111111112",
+          "id": "00000000-0000-0000-0000-000000000000",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/src/resources/order/mutations.js
+++ b/src/resources/order/mutations.js
@@ -1,0 +1,19 @@
+import { getResolver } from '@globality/nodule-graphql';
+import {
+    OrderCreateInputType,
+    OrderType,
+} from './types';
+
+
+export default {
+    orderCreate: {
+        type: OrderType,
+        description: 'order.create',
+        args: {
+            input: {
+                type: OrderCreateInputType,
+            },
+        },
+        resolve: getResolver('order.create'),
+    },
+};

--- a/src/resources/order/queries.js
+++ b/src/resources/order/queries.js
@@ -1,0 +1,35 @@
+import { getResolverPipeline } from '@globality/nodule-graphql';
+import {
+    GraphQLID,
+} from 'graphql';
+
+
+import { OrderListType } from './types';
+
+
+export default {
+    order: {
+        type: OrderListType,
+        args: {
+            id: {
+                type: GraphQLID,
+            },
+            customerId: {
+                type: GraphQLID,
+            },
+        },
+        resolve: getResolverPipeline(
+            (obj, args) => {
+                if (args.id) {
+                    return [
+                        'order.retrieve',
+                        'toItemList',
+                    ];
+                }
+                return [
+                    'order.search',
+                ];
+            },
+        ),
+    },
+};

--- a/src/resources/order/types/OrderCreateInputType.js
+++ b/src/resources/order/types/OrderCreateInputType.js
@@ -1,0 +1,17 @@
+import {
+    GraphQLID,
+    GraphQLInputObjectType,
+} from 'graphql';
+
+
+const OrderCreateInputType = new GraphQLInputObjectType({
+    name: 'OrderCreateInputType',
+    description: 'Order create input',
+    fields: {
+        customerId: {
+            type: GraphQLID,
+        },
+    },
+});
+
+export default OrderCreateInputType;

--- a/src/resources/order/types/OrderListType.js
+++ b/src/resources/order/types/OrderListType.js
@@ -1,0 +1,17 @@
+import {
+    GraphQLList,
+    GraphQLObjectType,
+} from 'graphql';
+
+import OrderType from './OrderType';
+
+const OrderListType = new GraphQLObjectType({
+    name: 'OrderListType',
+    fields: {
+        items: {
+            type: GraphQLList(OrderType),
+        },
+    },
+});
+
+export default OrderListType;

--- a/src/resources/order/types/OrderType.js
+++ b/src/resources/order/types/OrderType.js
@@ -1,0 +1,20 @@
+import {
+    GraphQLID,
+    GraphQLObjectType,
+    GraphQLString,
+} from 'graphql';
+
+
+const OrderType = new GraphQLObjectType({
+    name: 'OrderType',
+    fields: {
+        id: {
+            type: GraphQLID,
+        },
+        customerId: {
+            type: GraphQLID,
+        },
+    },
+});
+
+export default OrderType;

--- a/src/resources/order/types/OrderType.js
+++ b/src/resources/order/types/OrderType.js
@@ -1,7 +1,6 @@
 import {
     GraphQLID,
     GraphQLObjectType,
-    GraphQLString,
 } from 'graphql';
 
 

--- a/src/resources/order/types/index.js
+++ b/src/resources/order/types/index.js
@@ -1,0 +1,25 @@
+import { getResolverPipeline } from '@globality/nodule-graphql';
+import {
+    GraphQLID,
+} from 'graphql';
+
+
+import { default as OrderType } from './OrderType';
+import { default as OrderListType } from './OrderListType';
+
+export const Order = {
+    order: {
+        type: OrderListType,
+        args: {
+            id: {
+                type: GraphQLID,
+            },
+        },
+        resolve: getResolverPipeline(
+            (obj, args) => [
+                'order.retrieve',
+                'toItemList',
+            ],
+        ),
+    },
+};

--- a/src/resources/order/types/index.js
+++ b/src/resources/order/types/index.js
@@ -1,25 +1,3 @@
-import { getResolverPipeline } from '@globality/nodule-graphql';
-import {
-    GraphQLID,
-} from 'graphql';
-
-
-import { default as OrderType } from './OrderType';
-import { default as OrderListType } from './OrderListType';
-
-export const Order = {
-    order: {
-        type: OrderListType,
-        args: {
-            id: {
-                type: GraphQLID,
-            },
-        },
-        resolve: getResolverPipeline(
-            (obj, args) => [
-                'order.retrieve',
-                'toItemList',
-            ],
-        ),
-    },
-};
+export { default as OrderCreateInputType } from './OrderCreateInputType';
+export { default as OrderListType } from './OrderListType';
+export { default as OrderType } from './OrderType';

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,0 +1,3 @@
+import { bind } from '@globality/nodule-config';
+
+bind('graphql.transforms.toItemList', () => item => ({ items: item ? [item] : [] })); 

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,3 +1,3 @@
 import { bind } from '@globality/nodule-config';
 
-bind('graphql.transforms.toItemList', () => item => ({ items: item ? [item] : [] })); 
+bind('graphql.transforms.toItemList', () => item => ({ items: item ? [item] : [] }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,10 +173,10 @@
     lodash "^4.17.5"
     memcached "^2.2.2"
 
-"@globality/nodule-openapi@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@globality/nodule-openapi/-/nodule-openapi-0.14.0.tgz#71a003d04bfdbe830727ea87a6befb4848a3949e"
-  integrity sha512-U1/M4/i7aZm8tgfFmnH9OulSaATrdT635oiQ5O2w2h1h7TQFksVzRlcq/4fIKlF7TwhDKnOt1hnSBiL9lX8NMA==
+"@globality/nodule-openapi@^0.16.0":
+  version "0.16.1"
+  resolved "https://registry.yarnpkg.com/@globality/nodule-openapi/-/nodule-openapi-0.16.1.tgz#ebfcbddf295fde99903ef9a6b6046a7a2eaad297"
+  integrity sha512-vwW5Lp1HwyQ9EIhdW1mJG2EguOrjmeZL5YY4acO8tzWjnfJOcuRioASqg7tIdH9TO9vU9RVFCcTshEZmWRDSvQ==
   dependencies:
     "@globality/nodule-config" "^2.3.0"
     axios "^0.18.1"


### PR DESCRIPTION
This PR covers 80% of the core graphQL functionality we care about. The rest is special cases around connection resources through resolvers and performance features like batching and caching. 

Don't be scared by the large diff, most of it is adding the auto-generated json file for the [microcosm-sample-service](https://github.com/globality-corp/microcosm-sample-service) swagger client.

Here are samples of the queries/mutations include in this PR. You can try running this with `microcosm-sample-service` locally and putting these queries into graphql to make sure the queries/mutations work.

Create mutation:
```
mutation createOrder($input:OrderCreateInputType) {
  orderCreate(input: $input) {
      id,
      customerId
  }
}
```

Variables:
```
{
  "input": {
    "customerId": "46a17da5-49bf-4bf8-a3c8-e5d28837dff5"
  }
}
```

Result:

```
{
  "data": {
    "orderCreate": {
      "id": "802acbbd-ed84-4f30-8fa9-d944049c3818",
      "customerId": "46a17da5-49bf-4bf8-a3c8-e5d28837dff5"
    }
  }
}
```



Search query:
```
query {
  order {
    items {
      id,
      customerId
    }
  }
}
```

Result:

```
{
  "data": {
    "order": {
      "items": [
        {
          "id": "35ccaf94-606c-4516-a97f-27ba4597ce45",
          "customerId": "fe9f1a7d-9e02-4dc5-86f6-fcc9729fd877"
        },
        {
          "id": "092c96ab-48d2-406c-a225-7f61f6d6b767",
          "customerId": "4bca6dd3-4b29-4b25-bde5-5f6d3535cdb0"
        }
      ]
    }
  }
}
```

Retrieve query:
```
query($id:ID){
  order(id: $id) {
    items {
      id,
      customerId
    }
  }
}
```

Variables:
```
{
  "id": "35ccaf94-606c-4516-a97f-27ba4597ce45"
}
```

Result:
```
{
  "data": {
    "order": {
      "items": [
        {
          "id": "35ccaf94-606c-4516-a97f-27ba4597ce45",
          "customerId": "fe9f1a7d-9e02-4dc5-86f6-fcc9729fd877"
        }
      ]
    }
  }
}
```